### PR TITLE
chore/workflows: use short sha1 for dev releases.

### DIFF
--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -225,8 +225,11 @@ jobs:
 
         # Create release
         if [ -n "$DEV_COMMIT" ]; then
+          DEV_COMMIT_SHORT=${DEV_COMMIT::7}
+
           gh release create "$TAG_NAME" \
-            --title "$TAG_NAME" \
+            --title "commit-$DEV_COMMIT_SHORT" \
+            --notes "[$DEV_COMMIT_SHORT](https://github.com/gwdevhub/GWToolboxpp/commit/$DEV_COMMIT)" \
             --prerelease \
             GWToolboxdll.dll RawDialogs.dll SpeedrunScriptingTools.dll GWToolboxdll.pdb.gz gwca.dll
         else


### PR DESCRIPTION
To make the dev releases easier to browse and compare with GWToolbox dev commits. Like if we were using `git rev-parse --short dev`. Also include a link to the commit for convenience.