### PR TITLE
fix: do not select items on minimap

### DIFF
--- a/GWToolboxdll/Widgets/Minimap/Minimap.cpp
+++ b/GWToolboxdll/Widgets/Minimap/Minimap.cpp
@@ -1681,8 +1681,8 @@ void Minimap::SelectTarget(const GW::Vec2f pos)
     const GW::Agent* closest = nullptr;
 
     for (const auto* agent : *agents) {
-        if (!agent) continue;
-
+        const auto agent_is_locked_chest = agent && agent->GetIsGadgetType() && agent->GetAsAgentGadget()->gadget_id == GW::Constants::ModelID::LockedChest;
+        if (!agent_is_locked_chest && !(agent && agent->GetIsLivingType())) continue;
         const float new_distance = GetSquareDistance(pos, agent->pos);
         if (distance > new_distance) {
             distance = new_distance;


### PR DESCRIPTION
There was an issue with the current patch for invisible NPC targeting. As it stood, the patch was letting me select all kinds of things on the minimap that weren't supposed to be selected including chests, interactive items (e.g. dungeon traps), etc... Sometimes, because invisible NPCs are superposed on top of some items (my understanding is that sometimes, invisible NPCs are precursors to some items that will pop later-on), the previous patch would select the item rather than selecting the invisible NPC underneath it, the later being the correct 6.5 toolbox behavior (or traditional "cheat toolbox behavior"). 

I spent some time doing some RE on gwca.dll to see if we could keep `GetAgentMatchesFlags` from upstream and apply some bitmask to specifically ignore invisible NPCs, but it seems ultimately that all ends-up in GW.exe so nothing we can do there. 

Instead, we apply a small patch to the upstream version of this method and swap `GetAgentMatchesFlags` with `GetIsLivingType`. I tested it in-game and this seems to be the original behavior of "selecting invisible NPCs".