### PR TITLE
change: always produce crash dumps

### DIFF
--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -15,7 +15,9 @@ jobs:
     outputs:
       body: ${{ steps.check.outputs.body }}
       dev_commit: ${{ steps.check.outputs.dev_commit }}
+      dev_commit_short: ${{ steps.check.outputs.dev_commit_short }}
       tag: ${{ steps.check.outputs.tag }}
+      beta_tag: ${{ steps.check.outputs.beta_tag }}
       run: ${{ steps.check.outputs.run }}
     steps:
     - name: Checkout repository
@@ -32,6 +34,7 @@ jobs:
         BODY=$(gh api repos/gwdevhub/GWToolboxpp/releases/latest --jq .body)
         TAG=$(gh api repos/gwdevhub/GWToolboxpp/releases/latest --jq .tag_name)
         DEV_COMMIT=$(gh api repos/gwdevhub/GWToolboxpp/commits/dev --jq .sha)
+        DEV_COMMIT_SHORT=${DEV_COMMIT::7}
         echo "Latest upstream release tag: $TAG"
         {
           echo "body<<EOF"
@@ -40,14 +43,16 @@ jobs:
         } >> "$GITHUB_OUTPUT"
         echo "tag=$TAG" >> "$GITHUB_OUTPUT"
         echo "dev_commit=$DEV_COMMIT" >> "$GITHUB_OUTPUT"
+        echo "dev_commit_short=$DEV_COMMIT_SHORT" >> "$GITHUB_OUTPUT"
 
         if git show-ref --tags --quiet --verify "refs/tags/$TAG"; then
-          if [[ -n "$(git tag -l '*_$DEV_COMMIT')" ]]; then
+          if [[ -n "$(git tag -l "*_$DEV_COMMIT_SHORT")" ]]; then
             echo "Already processed."
             echo "run=false" >> "$GITHUB_OUTPUT"
           else
             echo "New dev version detected."
             echo "run=dev" >> "$GITHUB_OUTPUT"
+            echo "beta_tag=_Beta_$DEV_COMMIT_SHORT" >> "$GITHUB_OUTPUT"
           fi
         else
           echo "New stable version detected."
@@ -160,14 +165,14 @@ jobs:
       run: |
         CMAKE_ARGS="--preset=vcpkg"
         if [ "$IS_DEV_BUILD" = "true" ]; then
-          CMAKE_ARGS="$CMAKE_ARGS -DGWTOOLBOXDLL_VERSION_BETA=_Beta_$DEV_COMMIT"
+          CMAKE_ARGS="$CMAKE_ARGS -DGWTOOLBOXDLL_VERSION_BETA=$BETA_TAG"
         fi
         cmake $GITHUB_WORKSPACE $CMAKE_ARGS
       env:
         VCPKG_ROOT: ${{ env.VCPKG_ROOT }}
         VCPKG_BINARY_SOURCES: "clear;x-gha,readwrite"
         IS_DEV_BUILD: ${{ needs.check.outputs.run == 'dev' }}
-        DEV_COMMIT: ${{ needs.check.outputs.dev_commit }}
+        BETA_TAG: ${{ needs.check.outputs.beta_tag }}
 
     - name: Build
       working-directory: ${{runner.workspace}}/GWToolboxpp/build
@@ -185,7 +190,8 @@ jobs:
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         RELEASE_NOTES: ${{ needs.check.outputs.body }}
-        DEV_COMMIT: ${{ needs.check.outputs.run == 'dev' && needs.check.outputs.dev_commit || '' }}
+        DEV_COMMIT_SHORT: ${{ needs.check.outputs.run == 'dev' && needs.check.outputs.dev_commit_short || '' }}
+        BETA_TAG: ${{ needs.check.outputs.beta_tag }}
       run: |
         VERSION=$(sed -n 's/.*set(GWTOOLBOXDLL_VERSION "\(.*\)").*/\1/p' CMakeLists.txt | tr -d '\r')
         BETA=$(sed -n 's/.*set(GWTOOLBOXDLL_VERSION_BETA "\(.*\)").*/\1/p' CMakeLists.txt | tr -d '\r')
@@ -195,8 +201,8 @@ jobs:
           exit 1
         fi
 
-        if [ -n "$DEV_COMMIT" ]; then
-          TAG_NAME="${VERSION}_Beta_$DEV_COMMIT"
+        if [ -n "$DEV_COMMIT_SHORT" ]; then
+          TAG_NAME="${VERSION}${BETA_TAG}"
         else
           if [ -z "$BETA" ]; then
             TAG_NAME="${VERSION}_Release"
@@ -233,12 +239,10 @@ jobs:
         gzip -c "$BIN_DIR/GWToolboxdll.pdb" > GWToolboxdll.pdb.gz
 
         # Create release
-        if [ -n "$DEV_COMMIT" ]; then
-          DEV_COMMIT_SHORT=${DEV_COMMIT::7}
-
+        if [ -n "$DEV_COMMIT_SHORT" ]; then
           gh release create "$TAG_NAME" \
             --title "commit-$DEV_COMMIT_SHORT" \
-            --notes "[$DEV_COMMIT_SHORT](https://github.com/gwdevhub/GWToolboxpp/commit/$DEV_COMMIT)" \
+            --notes "[$DEV_COMMIT_SHORT](https://github.com/gwdevhub/GWToolboxpp/commit/$DEV_COMMIT_SHORT)" \
             --prerelease \
             GWToolboxdll.dll DialogsWindow.dll RawDialogs.dll SpeedrunScriptingTools.dll GWToolboxdll.pdb.gz gwca.dll
         else

--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -157,10 +157,17 @@ jobs:
       # access regardless of the host operating system
       shell: bash
       working-directory: ${{runner.workspace}}/GWToolboxpp/build
-      run: cmake $GITHUB_WORKSPACE --preset=vcpkg
-      env:
-        VCPKG_ROOT: ${{ env.VCPKG_ROOT }}
-        VCPKG_BINARY_SOURCES: "clear;x-gha,readwrite"
+      run: |
+        CMAKE_ARGS="--preset=vcpkg"
+        if [ "$IS_DEV_BUILD" = "true" ]; then
+            CMAKE_ARGS="$CMAKE_ARGS -DGWTOOLBOXDLL_VERSION_BETA=commit-$DEV_COMMIT"
+            fi
+            cmake $GITHUB_WORKSPACE $CMAKE_ARGS
+          env:
+            VCPKG_ROOT: ${{ env.VCPKG_ROOT }}
+            VCPKG_BINARY_SOURCES: "clear;x-gha,readwrite"
+            IS_DEV_BUILD: ${{ needs.check.outputs.run == 'dev' }}
+            DEV_COMMIT: ${{ needs.check.outputs.dev_commit }}
 
     - name: Build
       working-directory: ${{runner.workspace}}/GWToolboxpp/build

--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -42,7 +42,7 @@ jobs:
         echo "dev_commit=$DEV_COMMIT" >> "$GITHUB_OUTPUT"
 
         if git show-ref --tags --quiet --verify "refs/tags/$TAG"; then
-          if git show-ref --tags --quiet --verify "refs/tags/commit-$DEV_COMMIT"; then
+          if [[ -n "$(git tag -l '*_$DEV_COMMIT')" ]]; then
             echo "Already processed."
             echo "run=false" >> "$GITHUB_OUTPUT"
           else
@@ -160,14 +160,14 @@ jobs:
       run: |
         CMAKE_ARGS="--preset=vcpkg"
         if [ "$IS_DEV_BUILD" = "true" ]; then
-            CMAKE_ARGS="$CMAKE_ARGS -DGWTOOLBOXDLL_VERSION_BETA=commit-$DEV_COMMIT"
-            fi
-            cmake $GITHUB_WORKSPACE $CMAKE_ARGS
-          env:
-            VCPKG_ROOT: ${{ env.VCPKG_ROOT }}
-            VCPKG_BINARY_SOURCES: "clear;x-gha,readwrite"
-            IS_DEV_BUILD: ${{ needs.check.outputs.run == 'dev' }}
-            DEV_COMMIT: ${{ needs.check.outputs.dev_commit }}
+          CMAKE_ARGS="$CMAKE_ARGS -DGWTOOLBOXDLL_VERSION_BETA=_Beta_$DEV_COMMIT"
+        fi
+        cmake $GITHUB_WORKSPACE $CMAKE_ARGS
+      env:
+        VCPKG_ROOT: ${{ env.VCPKG_ROOT }}
+        VCPKG_BINARY_SOURCES: "clear;x-gha,readwrite"
+        IS_DEV_BUILD: ${{ needs.check.outputs.run == 'dev' }}
+        DEV_COMMIT: ${{ needs.check.outputs.dev_commit }}
 
     - name: Build
       working-directory: ${{runner.workspace}}/GWToolboxpp/build
@@ -196,7 +196,7 @@ jobs:
         fi
 
         if [ -n "$DEV_COMMIT" ]; then
-          TAG_NAME="commit-$DEV_COMMIT"
+          TAG_NAME="${VERSION}_Beta_$DEV_COMMIT"
         else
           if [ -z "$BETA" ]; then
             TAG_NAME="${VERSION}_Release"

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -7,7 +7,9 @@ project(gwtoolbox)
 set(GWTOOLBOXEXE_VERSION "4.6")
 set(GWTOOLBOXEXE_MODULE_VERSION "4,6,0,0") # used for exe module info. See GWToolbox/GWToolbox.rc
 set(GWTOOLBOXDLL_VERSION "8.15")
-set(GWTOOLBOXDLL_VERSION_BETA "") # can be anything. Marks beta version if not empty.
+if(NOT DEFINED GWTOOLBOXDLL_VERSION_BETA)
+    set(GWTOOLBOXDLL_VERSION_BETA "") # can be anything. Marks beta version if not empty.
+endif()
 set(GWTOOLBOX_MODULE_VERSION "8,15,0,0") # used for Dll module info. See GWToolboxdll/GWToolbox.rc
 
 

--- a/GWToolboxdll/GWToolbox.cpp
+++ b/GWToolboxdll/GWToolbox.cpp
@@ -556,7 +556,7 @@ namespace {
     {
         __try {
             return WndProc(hWnd, Message, wParam, lParam);
-        } __except (EXCEPTION_EXECUTE_HANDLER) {
+        } __except (EXCEPT_EXPRESSION_ENTRY) {
             return CallWindowProc(OldWndProc, hWnd, Message, wParam, lParam);
         }
     }

--- a/GWToolboxdll/Modules/CrashHandler.cpp
+++ b/GWToolboxdll/Modules/CrashHandler.cpp
@@ -147,25 +147,8 @@ LONG WINAPI CrashHandler::Crash(EXCEPTION_POINTERS* pExceptionPointers, const ch
         }
     }
 
-
-#ifndef _DEBUG
-    if (!Updater::IsLatestVersion()) {
-        const std::wstring error_message = L"YOU ARE NOT USING THE LATEST VERSION OF GWTOOLBOX++!\n\n"
-            L"Please update to the latest version before reporting any issues.\n"
-            L"No crash dump will be created because the issue may have already been fixed.";
-
-        MessageBoxW(nullptr, error_message.c_str(), L"GWToolbox++ - Outdated Version", MB_OK | MB_ICONERROR | MB_SYSTEMMODAL | MB_TOPMOST);
-        TerminateProcess(GetCurrentProcess(), 1);
-    }
-    if (!PluginModule::GetPlugins().empty()) {
-        const std::wstring error_message = L"YOU ARE USING PLUGINS!\n\n"
-            L"Do not report issues that happen while you are using plugins.\n"
-            L"No crash dump will be created because the issue may not come from Toolbox.";
-
-        MessageBoxW(nullptr, error_message.c_str(), L"GWToolbox++ - Plugins used", MB_OK | MB_ICONERROR | MB_SYSTEMMODAL | MB_TOPMOST);
-        TerminateProcess(GetCurrentProcess(), 1);
-    }
-#endif
+    const bool outdated_version = !Updater::IsLatestVersion();
+    const bool plugins_loaded = !PluginModule::GetPlugins().empty();
 
     const std::wstring crash_folder = Resources::GetPath(L"crashes");
 
@@ -242,6 +225,16 @@ LONG WINAPI CrashHandler::Crash(EXCEPTION_POINTERS* pExceptionPointers, const ch
     }
     else {
         error_info = L"Guild Wars crashed!\n\n";
+
+        if (outdated_version) {
+            error_info += L"WARNING: You are not using the latest version of GWToolbox++.\n"
+                L"Please update before reporting any issues, as the crash may have already been fixed.\n\n";
+        }
+
+        if (plugins_loaded) {
+            error_info += L"WARNING: Plugins were loaded. The crash may not be caused by GWToolbox.\n"
+                L"Do not report this issue to the GWToolbox developers unless you can reproduce it without plugins.\n\n";
+        }
 
         if (tb_exception_message && *tb_exception_message) {
             error_info += std::format(L"{}\n\n", TextUtils::StringToWString(tb_exception_message));

--- a/GWToolboxdll/Modules/Updater.cpp
+++ b/GWToolboxdll/Modules/Updater.cpp
@@ -73,14 +73,8 @@ namespace {
                 continue;
             }
             auto tag_name = js["tag_name"].get<std::string>();
-            // Handle commit-based prerelease tags from gwtasdevs CI.
-            // These have no version in the tag, so use the compiled-in version;
-            // the file size comparison will determine if it's a newer build.
-            const bool is_commit_tag = tag_name.starts_with("commit-");
-            const auto version_number_len = is_commit_tag
-                ? std::string::npos
-                : tag_name.find(tag_name.contains("_Release") ? "_Release" : "_Beta", 0);
-            if (version_number_len == std::string::npos && !is_commit_tag) {
+            const auto version_number_len = tag_name.find(tag_name.contains("_Release") ? "_Release" : "_Beta", 0);
+            if (version_number_len == std::string::npos) {
                 continue;
             }
             if (!(js.contains("assets") && js["assets"].is_array() && js["assets"].size() > 0)) {
@@ -100,17 +94,9 @@ namespace {
                     continue; // This release doesn't have a dll download.
                 }
                 release->download_url = asset["browser_download_url"].get<std::string>();
-                if (is_commit_tag) {
-                    // commit-* builds embed the tag in GWTOOLBOXDLL_VERSION_BETA,
-                    // so construct the version the same way: base version + tag_name.
-                    release->version = GWTOOLBOXDLL_VERSION;
-                    release->version.append(tag_name);
-                }
-                else {
-                    release->version = tag_name.substr(0, version_number_len);
-                    if (is_prerelease) {
-                        release->version += tag_name.substr(version_number_len + 1);
-                    }
+                release->version = tag_name.substr(0, version_number_len);
+                if (is_prerelease) {
+                    release->version += tag_name.substr(version_number_len + 1);
                 }
                 std::ranges::transform(release->version, release->version.begin(), [](const auto chr) { return static_cast<char>(std::tolower(chr)); });
                 release->body = js["body"].get<std::string>();

--- a/GWToolboxdll/Modules/Updater.cpp
+++ b/GWToolboxdll/Modules/Updater.cpp
@@ -73,8 +73,14 @@ namespace {
                 continue;
             }
             auto tag_name = js["tag_name"].get<std::string>();
-            const auto version_number_len = tag_name.find(tag_name.contains("_Release") ? "_Release" : "_Beta", 0);
-            if (version_number_len == std::string::npos) {
+            // Handle commit-based prerelease tags from gwtasdevs CI.
+            // These have no version in the tag, so use the compiled-in version;
+            // the file size comparison will determine if it's a newer build.
+            const bool is_commit_tag = tag_name.starts_with("commit-");
+            const auto version_number_len = is_commit_tag
+                ? std::string::npos
+                : tag_name.find(tag_name.contains("_Release") ? "_Release" : "_Beta", 0);
+            if (version_number_len == std::string::npos && !is_commit_tag) {
                 continue;
             }
             if (!(js.contains("assets") && js["assets"].is_array() && js["assets"].size() > 0)) {
@@ -94,9 +100,17 @@ namespace {
                     continue; // This release doesn't have a dll download.
                 }
                 release->download_url = asset["browser_download_url"].get<std::string>();
-                release->version = tag_name.substr(0, version_number_len);
-                if (is_prerelease) {
-                    release->version += tag_name.substr(version_number_len + 1);
+                if (is_commit_tag) {
+                    // commit-* builds embed the tag in GWTOOLBOXDLL_VERSION_BETA,
+                    // so construct the version the same way: base version + tag_name.
+                    release->version = GWTOOLBOXDLL_VERSION;
+                    release->version.append(tag_name);
+                }
+                else {
+                    release->version = tag_name.substr(0, version_number_len);
+                    if (is_prerelease) {
+                        release->version += tag_name.substr(version_number_len + 1);
+                    }
                 }
                 std::ranges::transform(release->version, release->version.begin(), [](const auto chr) { return static_cast<char>(std::tolower(chr)); });
                 release->body = js["body"].get<std::string>();


### PR DESCRIPTION
A rework of #1.

First commit: 
```
- We now ignore the "not latest version" and "using plugins" checks which would prevent
  us from producing crashes. We still print the messages in the exception modal for users.
  We could also print a message highlighting this is a TAS fork, and not vanilla TB?
  Lastly, it is worth noting that the "not latest version" will always be true for
  pre-release builds of TAS TB, and since we have a lot of pre-release users, we should
  probably update Updater.cpp to recognize TAS pre-releases appropriately, which will be the
  purpose of the second commit.
- For the crash dump from DialogsWindow to be produced, we had to update the SEH in
  GWToolbox.cpp. We use EXCEPT_EXPRESSION_ENTRY defined in Defines.h for that.
```

Second commit: 
```
Since we have pre-release users, not only can they now subscribe to "Beta" releases
within the Toolbox settings, but now the exception handler will not print the "newer
version available" message in the exception modal unnecessarily.

We use GWTOOLBOXDLL_VERSION_BETA to insert the dev commit (instead of the "beta"
label like Toolbox does).
```