### PR TITLE
fix: do not select corpses on minimap

### DIFF
--- a/GWToolboxdll/Widgets/Minimap/Minimap.cpp
+++ b/GWToolboxdll/Widgets/Minimap/Minimap.cpp
@@ -1681,8 +1681,9 @@ void Minimap::SelectTarget(const GW::Vec2f pos)
     const GW::Agent* closest = nullptr;
 
     for (const auto* agent : *agents) {
-        const auto agent_is_locked_chest = agent && agent->GetIsGadgetType() && agent->GetAsAgentGadget()->gadget_id == GW::Constants::ModelID::LockedChest;
-        if (!agent_is_locked_chest && !(agent && agent->GetIsLivingType())) continue;
+        if (!agent) continue;
+        if (!agent->GetIsLivingType()) continue;
+        if (agent->GetAsAgentLiving()->GetIsDead()) continue;
         const float new_distance = GetSquareDistance(pos, agent->pos);
         if (distance > new_distance) {
             distance = new_distance;


### PR DESCRIPTION
Fixes something 51aa707 did not handle: selecting corpses on the minimap (also not supposed to happen even with Invisible NPCs selection). Since we check for `GetIsLivingType()`, we don't need to check for locked chests anymore, these are excluded as well.

This now selects living agents and invisible NPCs.