### PR TITLE
ci: use VS 17 2022 in our CI pipeline

### DIFF
--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -60,7 +60,7 @@ jobs:
         fi
 
   build:
-    runs-on: windows-2025-vs2026
+    runs-on: windows-2022
     needs: check
     if: needs.check.outputs.run != 'false'
     timeout-minutes: 30
@@ -144,7 +144,7 @@ jobs:
       shell: bash
       working-directory: ${{runner.workspace}}/GWToolboxpp/build
       run: |
-        CMAKE_ARGS="--preset=vcpkg"
+        CMAKE_ARGS="--preset=vcpkg-tas-ci"
         if [ "$IS_DEV_BUILD" = "true" ]; then
           CMAKE_ARGS="$CMAKE_ARGS -DGWTOOLBOXDLL_VERSION_BETA=$BETA_TAG"
         fi

--- a/.gitignore
+++ b/.gitignore
@@ -21,6 +21,8 @@ CMakeCache.txt
 *.tlog
 *.recipe
 *.res
+# Cmake workaround
+CMakeUserPresets.json
 
 # Bloated Windows Databases
 *.sdf

--- a/CMakeUserPresets.json
+++ b/CMakeUserPresets.json
@@ -1,0 +1,11 @@
+{
+  "version": 3,
+  "configurePresets": [
+    {
+      "name": "vcpkg-tas-ci",
+      "inherits": "vcpkg",
+      "generator": "Visual Studio 17 2022",
+      "binaryDir": "${sourceDir}/build"
+    }
+  ]
+}


### PR DESCRIPTION
Define a CMakeUserPresets.json which uses the VS 17 2022 generator. We add this file to .gitignore as it is not typically tracked so that maintainers of this repo can still edit it locally without tracking their local changes.