### PR TITLE
ci: remove underscore prefix in dev releases

### DIFF
--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -52,7 +52,7 @@ jobs:
           else
             echo "New dev version detected."
             echo "run=dev" >> "$GITHUB_OUTPUT"
-            echo "beta_tag=_Beta_$DEV_COMMIT_SHORT" >> "$GITHUB_OUTPUT"
+            echo "beta_tag=Beta_$DEV_COMMIT_SHORT" >> "$GITHUB_OUTPUT"
           fi
         else
           echo "New stable version detected."
@@ -224,7 +224,7 @@ jobs:
         fi
 
         if [ -n "$DEV_COMMIT_SHORT" ]; then
-          TAG_NAME="${VERSION}${BETA_TAG}"
+          TAG_NAME="${VERSION}_${BETA_TAG}"
         else
           if [ -z "$BETA" ]; then
             TAG_NAME="${VERSION}_Release"
@@ -235,6 +235,7 @@ jobs:
 
         echo "Detected version: $VERSION"
         echo "Detected beta: $BETA"
+        echo "Detected dev commit: $DEV_COMMIT_SHORT"
         echo "Target tag: $TAG_NAME"
 
         # Check if tag exists


### PR DESCRIPTION
In TAS dev releases the cmake arg `-DGWTOOLBOXDLL_VERSION_BETA` always has a prefix which reads weird for users in the Toolbox settings in-game (e.g. `_Beta_e044d3c3`).

This removes it but keeps it in `TAG_NAME`. Also we show the detected dev commit if any to distinguish upstream beta/tas dev release.