### PR TITLE
GWSplits fixes

### DIFF
--- a/plugins/GWSplits/GWSplits.cpp
+++ b/plugins/GWSplits/GWSplits.cpp
@@ -19,7 +19,6 @@
 #include <GWCA/Managers/MapMgr.h>
 #include <GWCA/Managers/UIMgr.h>
 #include <GWCA/Managers/MemoryMgr.h>
-#include <GWCA/Managers/ChatMgr.h>
 
 #include <GWCA/GWCA.h>
 #include <GWCA/Utilities/Hooker.h>
@@ -208,7 +207,7 @@ namespace {
     {
         auto posX = (ImGui::GetCursorPosX() + ImGui::GetColumnWidth() - ImGui::CalcTextSize(s.c_str()).x - ImGui::GetScrollX() - 2 * ImGui::GetStyle().ItemSpacing.x);
         if (posX > ImGui::GetCursorPosX()) ImGui::SetCursorPosX(posX);
-        ImGui::Text(s.c_str());
+        ImGui::TextUnformatted(s.c_str()); // Fixed: ImGui::Text treated the string as a format string; '%' in output caused UB.
     }
     auto mix(ImVec4 a, ImVec4 b, float aNess)
     {
@@ -242,9 +241,7 @@ namespace {
         }
         timeDiff = std::min(timeDiff, earlyResultTimeMs);
         const auto redNess = float(timeDiff) / earlyResultTimeMs;
-        const auto result = ImGui::ColorConvertU32ToFloat4(mix(lightRed, red, 1.f - redNess));
-
-        return mix(lightRed, red, 1.f - redNess);
+        return mix(lightRed, red, 1.f - redNess); // Fixed: a dead 'result' variable and a duplicate mix() call were here.
     }
 
     std::string serialize(const Split& split)
@@ -585,7 +582,8 @@ void GWSplits::Update(float diff)
         bestPossibleTime = runTime;
     }
     
-    if (currentSplitIt == currentSplits.end() || !checkConditions(currentSplitIt->conditions, false)) return;
+    // Fixed: was firing for all trigger types; trigger-based splits must only complete on their packet callback, not here.
+    if (currentSplitIt == currentSplits.end() || currentSplitIt->trigger != Trigger::None || !checkConditions(currentSplitIt->conditions, false)) return;
     completeSplit(currentSplitIt);
 }
 
@@ -595,6 +593,10 @@ void GWSplits::resetRun()
     isCurrentRunTracked = false;
 
     segmentStart = 0;
+    runTime = 0;           // Fixed: these were not reset, so stale values persisted into the next run
+    segmentTime = 0;       // and the sumOfBest lazy-init guard (if sumOfBest == 0) skipped re-initialisation.
+    bestPossibleTime = 0;
+    sumOfBest = 0;
     lastSegmentColor = ImGui::ColorConvertFloat4ToU32(white);
     lastSegmentGain = 0;
 
@@ -715,7 +717,7 @@ void GWSplits::Draw(IDirect3DDevice9* pDevice)
 
         if (!currentRun->topText.empty()) {
             ImGui::SetCursorPosX((ImGui::GetWindowSize().x - ImGui::CalcTextSize(currentRun->topText.c_str()).x) * 0.5f);
-            ImGui::Text(currentRun->topText.c_str());
+            ImGui::TextUnformatted(currentRun->topText.c_str()); // Fixed: ImGui::Text with user-controlled string caused format-string UB on '%'.
             ImGui::Separator();
         }
         if (ImGui::BeginTable("tablename", 3, ImGuiTableFlags_RowBg)) {
@@ -737,7 +739,10 @@ void GWSplits::Draw(IDirect3DDevice9* pDevice)
                 displaySplits = displaySplits.subspan(std::max(start, 0), std::min(totalSplits, total));
             }
 
-            int previousSplitTime = 0;
+            // Fixed: was always 0, causing the first visible split's $duration to equal its absolute run time when the window was scrolled.
+            int previousSplitTime = displaySplits.data() > currentSplits.data()
+                ? std::prev(displaySplits.data())->currentTime
+                : 0;
 
             for (const auto& split : displaySplits) {
                 ImGui::TableNextRow();
@@ -765,22 +770,23 @@ void GWSplits::Draw(IDirect3DDevice9* pDevice)
                     }
                 }
 
-                if (&split == &*currentSplitIt) {
+                // Fixed: dereferencing end() when all splits are complete was UB.
+                if (currentSplitIt != currentSplits.end() && &split == &*currentSplitIt) {
                     ImGui::TableSetBgColor(ImGuiTableBgTarget_RowBg1, ImGui::GetColorU32(currentSplitColor));
                 }
 
                 ImGui::TableSetColumnIndex(0);
                 ImGui::SameLine();
-                ImGui::Text(split.name.c_str());
+                ImGui::TextUnformatted(split.name.c_str()); // Fixed: same format-string UB as topText.
                 ImGui::TableNextColumn();
 
                 if (split.completed) {
                     const auto timeDiff = split.currentTime - split.trackedTime;
                     ImGui::PushStyleColor(ImGuiCol_Text, getTimerColor(timeDiff, split.isPB));
-                    ImGui::Text(timeToString(timeDiff, ToStringStyle::SecondsCentiseconds).c_str());
+                    ImGui::TextUnformatted(timeToString(timeDiff, ToStringStyle::SecondsCentiseconds).c_str());
                     ImGui::PopStyleColor();
                 }
-                else if (isCurrentRunTracked && &split == &*currentSplitIt) {
+                else if (isCurrentRunTracked && currentSplitIt != currentSplits.end() && &split == &*currentSplitIt) { // Fixed: same end() dereference UB.
                     const auto currentTime = getRunTime();
                     const auto timeDiff = currentTime - split.trackedTime;
                     if (timeDiff > -earlyResultTimeMs) {
@@ -791,13 +797,13 @@ void GWSplits::Draw(IDirect3DDevice9* pDevice)
                             lastSegmentColor = getTimerColor(timeDiff, false);
                         }
                         ImGui::PushStyleColor(ImGuiCol_Text, getTimerColor(timeDiff, split.isPB));
-                        ImGui::Text(timeToString(timeDiff, ToStringStyle::SecondsCentiseconds).c_str());
+                        ImGui::TextUnformatted(timeToString(timeDiff, ToStringStyle::SecondsCentiseconds).c_str());
                         ImGui::PopStyleColor();
                     }
                 }
 
                 ImGui::TableNextColumn();
-                ImGui::Text(timeToString(split.trackedTime).c_str());
+                ImGui::TextUnformatted(timeToString(split.trackedTime).c_str());
 
                 if (split.completed) {
                     ImGui::PopID();
@@ -945,7 +951,7 @@ void GWSplits::DrawSettings()
         }
     }
 
-    ImGui::Text("Version 1.3.4");
+    ImGui::Text("Version 2.0.0");
 }
 
 void GWSplits::loadFromIniFile(const wchar_t* filePath)
@@ -960,7 +966,7 @@ void GWSplits::loadFromIniFile(const wchar_t* filePath)
     showBestPossibleTime = ini.GetBoolValue(Name(), "showBestPossibleTime", true);
     showSumOfBest = ini.GetBoolValue(Name(), "showSumOfBest", true);
     showLastSegment = ini.GetBoolValue(Name(), "showLastSegment", true);
-    fontSizeIndex = ini.GetLongValue(Name(), "fontSize", 2);
+    fontSizeIndex = std::clamp((int)ini.GetLongValue(Name(), "fontSize", 2), 0, 3); // Fixed: unclamped value from a corrupt ini caused out-of-bounds access on font_sizes[fontSizeIndex + 2].
     splitMessage = ini.GetValue(Name(), "splitMessage", "[$name] ~ Time: $time ~ Duration: $duration");
 
     if (std::string read = ini.GetValue(Name(), "runs", ""); !read.empty()) {
@@ -994,7 +1000,7 @@ void GWSplits::LoadSettings(const wchar_t* folder)
 
     if (runs.empty() && BackupManager::getInstance().backupCount(PluginUtils::StringToWString(Name())) > 0) 
     {
-        logMessage("No runs loaded, but automatic backups found. Type \"/restore " + std::string{Name()} + " help\" to see options for restoring backups", Name());
+        logMessage("No runs loaded, but automatic backups found. Automatic backups are stored in the settings folder.", Name());
     }
 }
 
@@ -1107,6 +1113,7 @@ void GWSplits::handleTrigger(Trigger triggerType, std::function<bool(const Split
         if (splitIt->trigger != triggerType || !extraConditions(*splitIt)) return;
 
         completeSplit(splitIt);
+        return; // Fixed: without this, the loop continued and chain-completed all subsequent trigger-type splits in a single packet callback.
     }
 }
 
@@ -1125,7 +1132,8 @@ void GWSplits::Initialize(ImGuiContext* ctx, ImGuiAllocFns fns, HMODULE toolbox_
         isCurrentRunTracked = false;
     });
 
-    GW::StoC::RegisterPacketCallback<GW::Packet::StoC::InstanceTimer>(&InstanceLoadStart_Entry, [this](GW::HookStatus*, GW::Packet::StoC::InstanceTimer* packet) -> void {
+    // Fixed: was &InstanceLoadStart_Entry — sharing one HookEntry across two registrations caused the second call to overwrite the first, silently dropping the InstanceLoadStart subscription.
+    GW::StoC::RegisterPacketCallback<GW::Packet::StoC::InstanceTimer>(&InstanceTimer_Entry, [this](GW::HookStatus*, GW::Packet::StoC::InstanceTimer* packet) -> void {
         if (GW::Map::GetInstanceType() == GW::Constants::InstanceType::Outpost)
         {
             // This is meant to correct slowloading but doesn't really work in outposts since the instance is active for as long as someone is in it
@@ -1221,7 +1229,6 @@ void GWSplits::Initialize(ImGuiContext* ctx, ImGuiAllocFns fns, HMODULE toolbox_
         const auto instance = static_cast<GWSplits*>(ToolboxPluginInstance());
         if (!instance) return;
 
-        // TODO this doesn't reset the current split
         instance->resetRun();
         instanceStart = now();
     });
@@ -1235,11 +1242,13 @@ void GWSplits::SignalTerminate()
 {
     ToolboxUIPlugin::SignalTerminate();
 
-    GW::StoC::RemovePostCallback<GW::Packet::StoC::InstanceLoadInfo>(&InstanceLoadStart_Entry);
-    GW::StoC::RemovePostCallback<GW::Packet::StoC::InstanceLoadInfo>(&InstanceTimer_Entry);
+    // Fixed: was RemovePostCallback<InstanceLoadInfo> for both — wrong removal function and wrong packet type; callbacks were never removed.
+    GW::StoC::RemoveCallback<GW::Packet::StoC::InstanceLoadStart>(&InstanceLoadStart_Entry);
+    GW::StoC::RemoveCallback<GW::Packet::StoC::InstanceTimer>(&InstanceTimer_Entry);
     GW::StoC::RemovePostCallback<GW::Packet::StoC::DisplayDialogue>(&DisplayDialogue_Entry);
-    GW::StoC::RemovePostCallback<GW::Packet::StoC::DungeonReward>(&DungeonReward_Entry);
-    GW::StoC::RemovePostCallback<GW::Packet::StoC::DoACompleteZone>(&DoACompleteZone_Entry);
+    // Fixed: was RemovePostCallback — wrong table for callbacks registered with RegisterPacketCallback; callbacks were never removed.
+    GW::StoC::RemoveCallback<GW::Packet::StoC::DungeonReward>(&DungeonReward_Entry);
+    GW::StoC::RemoveCallback<GW::Packet::StoC::DoACompleteZone>(&DoACompleteZone_Entry);
     GW::Chat::DeleteCommand(&ChatCmd_HookEntry, L"resetrun");
 
     InstanceInfo::getInstance().terminate();

--- a/plugins/Scripting/InstanceInfo.cpp
+++ b/plugins/Scripting/InstanceInfo.cpp
@@ -22,7 +22,6 @@
 namespace {
     GW::HookEntry InstanceLoadFile_Entry;
     GW::HookEntry UseItem_Entry;
-    GW::HookEntry FinishSkill_Entry;
     GW::HookEntry ManipulateMapObject_Entry;
     GW::HookEntry DungeonReward_Entry;
     GW::HookEntry CountdownStart_Entry;
@@ -120,8 +119,10 @@ void InstanceInfo::initialize()
 void InstanceInfo::terminate() 
 {
     GW::StoC::RemovePostCallback<GW::Packet::StoC::InstanceLoadFile>(&InstanceLoadFile_Entry);
-    GW::StoC::RemovePostCallback<GW::Packet::StoC::DungeonReward>(&DungeonReward_Entry);
-    GW::StoC::RemovePostCallback<GW::Packet::StoC::ManipulateMapObject>(&ManipulateMapObject_Entry);
+    // Fixed: was RemovePostCallback — wrong table for callbacks registered with RegisterPacketCallback; callbacks were never removed.
+    GW::StoC::RemoveCallback<GW::Packet::StoC::DungeonReward>(&DungeonReward_Entry);
+    GW::StoC::RemoveCallback<GW::Packet::StoC::ManipulateMapObject>(&ManipulateMapObject_Entry);
+    GW::StoC::RemoveCallbacks(&CountdownStart_Entry); // Fixed: CountdownStart_Entry was registered but had no matching remove call; dangling callback after plugin unload.
     RemoveUIMessageCallback(&UseItem_Entry, GW::UI::UIMessage::kSendUseItem);
 }
 
@@ -133,14 +134,17 @@ std::string InstanceInfo::getDecodedAgentName(GW::AgentID id)
         const wchar_t* encodedName = nullptr;
 
         // Check in agent infos
-        const auto& agentInfos = GW::GetWorldContext()->agent_infos;
+        // Fixed: GetWorldContext() was called twice with no null check and its result used directly; crashes during map transitions.
+        const auto* worldContext = GW::GetWorldContext();
+        if (!worldContext) return "";
+        const auto& agentInfos = worldContext->agent_infos;
         if (id >= agentInfos.size()) return "";
         encodedName = agentInfos[id].name_enc;
 
         // Check players
         if (!encodedName)
         {
-            for (const auto& player : GW::GetWorldContext()->players)
+            for (const auto& player : worldContext->players)
             {
                 if (player.agent_id == id) {
                     encodedName = player.name_enc;
@@ -155,6 +159,7 @@ std::string InstanceInfo::getDecodedAgentName(GW::AgentID id)
             const auto agent = GW::Agents::GetAgentByID(id);
             if (!agent || !agent->GetIsLivingType()) return "";
             const auto npc = GW::Agents::GetNPCByID(agent->GetAsAgentLiving()->player_number);
+            if (!npc) return ""; // Fixed: GetNPCByID() can return null; was dereferenced unconditionally.
             encodedName = npc->name_enc;
         }
 

--- a/plugins/Scripting/QuestInfo.cpp
+++ b/plugins/Scripting/QuestInfo.cpp
@@ -47,6 +47,7 @@ std::optional<QuestInfo::Quest> QuestInfo::getQuest(std::string_view name) const
 
     for (const auto& quest : *questLog) 
     {
+        if (!quest.name) continue; // Fixed: passing null to decodedStrings.find implicitly constructs a wstring via wcslen, crashing if null.
         const auto decodedIt = decodedStrings.find(quest.name);
         if (decodedIt == decodedStrings.end()) continue;
 
@@ -68,6 +69,7 @@ std::vector<QuestInfo::Objective> QuestInfo::listObjectives(GW::Constants::Quest
     const auto quest = std::ranges::find_if(*questLog, [&](const auto& quest) { return quest.quest_id == id; });
     if (quest == questLog->end()) return {};
 
+    if (!quest->objectives) return {}; // Fixed: passing null to decodedStrings.find crashed for quests not yet populated.
     const auto decodedIt = decodedStrings.find(quest->objectives);
     if (decodedIt == decodedStrings.end()) return {};
     const auto& decoded = WStringToString(decodedIt->second);
@@ -85,7 +87,9 @@ std::vector<QuestInfo::Objective> QuestInfo::listObjectives(GW::Constants::Quest
 
 std::vector<QuestInfo::Objective> QuestInfo::listMissionObjectives() const 
 {
-    const auto& objectives = GW::GetWorldContext()->mission_objectives;
+    const auto* worldContext = GW::GetWorldContext();
+    if (!worldContext) return {}; // Fixed: was dereferenced directly; crashed during map transitions.
+    const auto& objectives = worldContext->mission_objectives;
     std::vector<QuestInfo::Objective> result;
     result.reserve(objectives.size());
 
@@ -107,7 +111,8 @@ void QuestInfo::decodeStrings()
     {
         for (auto& quest : *questLog) 
         {
-            if (!decodedStrings.contains(quest.name)) 
+            if (quest.name && !decodedStrings.contains(quest.name)) { // Fixed: null check prevents wstring-from-null; slot pre-inserted so the pointer is stable before AsyncDecodeStr is called.
+                auto& slot = decodedStrings[quest.name];
                 GW::UI::AsyncDecodeStr(
                     quest.name,
                     [](void* param, const wchar_t* s) {
@@ -115,11 +120,13 @@ void QuestInfo::decodeStrings()
                         std::wstring* str = (std::wstring*)param;
                         *str = s;
                     },
-                    &decodedStrings[quest.name]
+                    &slot
                 );
+            }
             if (!quest.objectives)
                 objectivesToDecode.push(&quest);
-            else if (!decodedStrings.contains(quest.objectives)) 
+            else if (!decodedStrings.contains(quest.objectives)) { // Fixed: slot pre-inserted so pointer is stable before AsyncDecodeStr is called.
+                auto& slot = decodedStrings[quest.objectives];
                 GW::UI::AsyncDecodeStr(
                     quest.objectives,
                     [](void* param, const wchar_t* s) {
@@ -127,23 +134,29 @@ void QuestInfo::decodeStrings()
                         std::wstring* str = (std::wstring*)param;
                         *str = s;
                     },
-                    &decodedStrings[quest.objectives]
+                    &slot
                 );
+            }
         }
     }
 
-    for (const auto& objective : GW::GetWorldContext()->mission_objectives) 
-    {
-        if (!decodedStrings.contains(objective.enc_str))
-            GW::UI::AsyncDecodeStr(
-                getObjectiveContent(objective.enc_str).c_str(),
-                [](void* param, const wchar_t* s) {
-                    GWCA_ASSERT(param && s);
-                    std::wstring* str = (std::wstring*)param;
-                    *str = s;
-                },
-                &decodedStrings[objective.enc_str]
-            );
+    const auto* worldContext = GW::GetWorldContext();
+    if (worldContext) { // Fixed: was dereferenced directly; called from every StoC callback so crashed on any packet during a load screen.
+        for (const auto& objective : worldContext->mission_objectives) 
+        {
+            if (!decodedStrings.contains(objective.enc_str)) {
+                auto& slot = decodedStrings[objective.enc_str];
+                GW::UI::AsyncDecodeStr(
+                    getObjectiveContent(objective.enc_str).c_str(),
+                    [](void* param, const wchar_t* s) {
+                        GWCA_ASSERT(param && s);
+                        std::wstring* str = (std::wstring*)param;
+                        *str = s;
+                    },
+                    &slot
+                );
+            }
+        }
     }
 }
 
@@ -153,6 +166,7 @@ void QuestInfo::initialize()
 
     GW::StoC::RegisterPostPacketCallback<GW::Packet::StoC::InstanceLoadFile>(&InstanceLoadFile_Entry, [this](GW::HookStatus*, const auto*)
     {
+        objectivesToDecode = {}; // Fixed: without this, stale GW::Quest* pointers from the previous map's quest log remained in the queue and were dereferenced in update().
         decodeStrings();
         missionObjectiveStatus.clear();
     });
@@ -183,8 +197,9 @@ void QuestInfo::initialize()
 
 void QuestInfo::terminate()
 {
-    GW::StoC::RemovePostCallback<GW::Packet::StoC::ObjectiveUpdateName>(&ObjectiveUpdateName_Entry);
-    GW::StoC::RemovePostCallback<GW::Packet::StoC::ObjectiveDone>(&ObjectiveDone_Entry);
+    // Fixed: was RemovePostCallback — wrong table for callbacks registered with RegisterPacketCallback; callbacks were never removed.
+    GW::StoC::RemoveCallback<GW::Packet::StoC::ObjectiveUpdateName>(&ObjectiveUpdateName_Entry);
+    GW::StoC::RemoveCallback<GW::Packet::StoC::ObjectiveDone>(&ObjectiveDone_Entry);
     GW::StoC::RemovePostCallback<GW::Packet::StoC::InstanceLoadFile>(&InstanceLoadFile_Entry);
     GW::StoC::RemovePostCallback<GW::Packet::StoC::QuestAdd>(&QuestAdd_Entry);
     GW::StoC::RemovePostCallback<GW::Packet::StoC::DisplayDialogue>(&DisplayDialogue_Entry);
@@ -203,7 +218,8 @@ void QuestInfo::update()
     }
 
     GW::QuestMgr::RequestQuestInfo(quest);
-    if (quest->objectives)
+    if (quest->objectives) { // Fixed: slot pre-inserted so pointer is stable before AsyncDecodeStr is called.
+        auto& slot = decodedStrings[quest->objectives];
         GW::UI::AsyncDecodeStr(
             quest->objectives,
             [](void* param, const wchar_t* s) {
@@ -211,7 +227,8 @@ void QuestInfo::update()
                 std::wstring* str = (std::wstring*)param;
                 *str = s;
             },
-            &decodedStrings[quest->objectives]
+            &slot
         );
+    }
     objectivesToDecode.pop();
 }


### PR DESCRIPTION
I am not a GWSplits user but trying to set it up for UWSC I not only gave up because I can't figure out how to configure it properly, but I also kept experiencing a variety of crashes, so I gave it to Opus to do some audit rounds and find a plethora of issues. Since I am not a user, I can't really test it myself to make sure it still works as intended, but I thought maybe you could @MikeJerred. Fixes #24.

GWSplits.cpp
- `InstanceTimer` callback used `&InstanceLoadStart_Entry` instead of `&InstanceTimer_Entry`. `HookEntry*` is the unique key GWCA uses to index each registration; passing the same pointer to two `RegisterPacketCallback` calls causes the second to overwrite the first, silently dropping the `InstanceLoadStart` subscription entirely. Fixed by registering each callback with its own dedicated entry
- `SignalTerminate`: `RemovePostCallback<InstanceLoadInfo>` for both instance callbacks. Both were registered via `RegisterPacketCallback`, which stores entries in the pre-processing table; `RemovePostCallback` searches the post-processing table, so the lookup found nothing and the callbacks were never removed. The packet type was also wrong (`InstanceLoadInfo` instead of `InstanceLoadStart`/`InstanceTimer`), so even switching to `RemoveCallback` with the old type would have searched the right table but under the wrong header. Fixed to `RemoveCallback<InstanceLoadStart>` and `RemoveCallback<InstanceTimer>`
- `SignalTerminate`: `RemovePostCallback` for `DungeonReward` and `DoACompleteZone`, both registered via `RegisterPacketCallback`. Same wrong-table lookup as above. Fixed to `RemoveCallback`
- `handleTrigger()`: missing `return` after `completeSplit()` caused the loop to continue and chain-complete all subsequent trigger-type splits in a single packet callback
- `Update()`: condition check ran for all split types; trigger-based splits (`DungeonReward`, `DoaZoneComplete`, `DisplayDialog`) would fire immediately if their conditions passed without waiting for the actual in-game trigger packet. Fixed to only auto-complete splits whose trigger is `Trigger::None`
- `resetRun()`: `runTime`, `segmentTime`, `bestPossibleTime`, and `sumOfBest` were not zeroed, leaving stale values in the next run and causing the `sumOfBest` lazy-init guard (`if (sumOfBest == 0)`) to skip re-initialisation
- `loadFromIniFile()`: `fontSizeIndex` was not clamped; a corrupt ini value could produce an out-of-bounds access on `font_sizes[fontSizeIndex + 2]`. Clamped to [0, 3]
- `Draw()`: `ImGui::Text(userString)` used for split names and top text; user-controlled strings containing `%` caused format-string UB. Changed to `TextUnformatted()`
- `Draw()`: `previousSplitTime` was always 0 regardless of scroll position, so the `$duration` placeholder in split messages was wrong for any visible split that was not the first split of the run. Fixed by seeding from the predecessor of the first visible split
- `Draw()`: `currentSplitIt` was dereferenced as `&*currentSplitIt` for row highlighting and live-timer display without first checking `currentSplitIt != currentSplits.end()`; this was UB once all splits were completed. Fixed with explicit end-iterator guards
- `getTimerColor()`: a dead `result` variable and a duplicate `mix()` call were present in the red branch. Removed
- Removed duplicate `#include <GWCA/Managers/ChatMgr.h>`
- Removed stale TODO comment in `/resetrun` handler
- Fixed misleading log message advertising the commented-out `/restore` command

QuestInfo.cpp
- `terminate()`: `RemovePostCallback` for `ObjectiveUpdateName` and `ObjectiveDone`, both registered via `RegisterPacketCallback`. Same wrong-table lookup as above. Fixed to `RemoveCallback`
- `listMissionObjectives()` / `decodeStrings()`: no null check on `GW::GetWorldContext()`, crashing during map transitions and load screens. Fixed with early-return guards
- `AsyncDecodeStr` slot insertion separated from the call site to make the intent explicit and avoid ambiguity around evaluation order
- `objectivesToDecode` queue never cleared on `InstanceLoadFile`, leaving stale `GW::Quest*` pointers from the previous map to be dereferenced in `update()`. Fixed by resetting on `InstanceLoadFile`
- `listObjectives()`: `quest->objectives` passed to `unordered_map::find` with no null check; constructing `std::wstring` from a null pointer calls `wcslen` on it and crashes for quests not yet populated. Fixed by returning early if null
- `getQuest()` / `decodeStrings()`: same implicit `wstring`-from-null on `quest.name`. Fixed with null guards

InstanceInfo.cpp
- `terminate()`: `RemovePostCallback` for `DungeonReward` and `ManipulateMapObject`, both registered via `RegisterPacketCallback`. Same wrong-table lookup as above. Fixed to `RemoveCallback`
- `CountdownStart_Entry` registered via `RegisterPacketCallback` but never removed in `terminate()`, leaving a dangling callback after plugin unload. Fixed by adding `RemoveCallbacks(&CountdownStart_Entry)`
- `getDecodedAgentName()`: `GW::GetWorldContext()` called with no null check; the result was used directly during map transitions. Fixed by storing the result once and early-returning if null
- `getDecodedAgentName()`: `GetNPCByID()` return value dereferenced without a null check. Fixed with `if (!npc) return ""`
- Removed unused `FinishSkill_Entry` declaration