### PR TITLE
Revert "fix: allow toolbox in the guild hall"

### DIFF
--- a/GWToolboxdll/GWToolbox.cpp
+++ b/GWToolboxdll/GWToolbox.cpp
@@ -779,7 +779,7 @@ bool GWToolbox::IsProfilingEnabled()
 bool GWToolbox::ShouldDisableToolbox(GW::Constants::MapID map_id)
 {
     const auto m = GW::Map::GetMapInfo(map_id);
-    return m && m->GetIsPvP();
+    return m && (m->GetIsPvP() || m->GetIsGuildHall());
 }
 
 bool GWToolbox::IsInitialized()


### PR DESCRIPTION
Prepare for next beta release in which gwdevhub/GWToolboxpp@32c589abe  will be included.